### PR TITLE
fix: remove patch version from min_ansible_version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   description: This role installs and configures icingaweb2
   company: Adfinis AG
   license: GNU General Public License v3
-  min_ansible_version: 2.15
+  min_ansible_version: '2.15'
   platforms:
     - name: Debian
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,7 @@ galaxy_info:
   description: This role installs and configures icingaweb2
   company: Adfinis AG
   license: GNU General Public License v3
-  min_ansible_version: 2.15.0
+  min_ansible_version: 2.15
   platforms:
     - name: Debian
       versions:


### PR DESCRIPTION
This maybe fixes an issue with ansible/ansible-galaxy not respecting the min_ansible_version 